### PR TITLE
Added commands to edit the config variables

### DIFF
--- a/Model/TurtleAddress.cs
+++ b/Model/TurtleAddress.cs
@@ -4,7 +4,7 @@ namespace TurtleBot.Services
 {
     public class TurtleWallet
     {
-        public string Address { get; private set; }
+        public string Address { get; }
 
         private TurtleWallet(string address)
         {

--- a/Modules/ConfigModule.cs
+++ b/Modules/ConfigModule.cs
@@ -48,12 +48,7 @@ namespace TurtleBot.Services
             var query = change.Split(" ");
 
             var configName = _configNames[query[0]];
-
-            if (configName.Equals(""))
-            {
-                throw new KeyNotFoundException();
-            }
-
+            
             if (query[1].Equals("reset"))
             {
                 Reset(configName);

--- a/Modules/ConfigModule.cs
+++ b/Modules/ConfigModule.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.ConstrainedExecution;
+using Microsoft.Extensions.Configuration;
+
+namespace TurtleBot.Services
+{
+    public class ConfigModule
+    {
+        private readonly IConfiguration _config;
+
+        private readonly Tuple<string, string>[] _configDefualts;
+
+        private readonly Dictionary<string, WrapperService> refrences =
+            new Dictionary<string, WrapperService>();
+
+        private readonly Dictionary<string, string> _configNames = new Dictionary<string, string>();
+
+        public string this[string key] => _config[key];
+
+        public ConfigModule(IConfiguration config)
+        {
+            _configDefualts = config.GetChildren().Select(child => Tuple.Create(child.Key, child.Value)).ToArray();
+
+            _config = config;
+        }
+
+        public void Enable(string key, string name) => _configNames.Add(key, name);
+
+        public void AddBinding(WrapperService wraper, string key)
+        {
+
+            var configName = _configNames[key];
+
+            if (configName.Equals(""))
+            {
+                throw new KeyNotFoundException();
+            }
+            
+            refrences.Add(configName, wraper);
+            
+            wraper.SetValue(_configDefualts.First(def => def.Item1.Equals(configName)).Item2);
+        }
+
+        public void Execute(string change)
+        {
+            var query = change.Split(" ");
+
+            var configName = _configNames[query[0]];
+
+            if (configName.Equals(""))
+            {
+                throw new KeyNotFoundException();
+            }
+
+            if (query[1].Equals("reset"))
+            {
+                Reset(configName);
+            }
+            else
+            {
+                SetValue(configName, query[1]);
+            }
+        }
+
+        public string GetValue(string key)
+        {
+            return _config[_configNames[key]];
+        }
+
+        private void SetValue(string key, string value)
+        {
+            _config[key] = value;
+
+            foreach (var refrence in refrences.Where(refrence => refrence.Key.Equals(key)))
+            {
+                refrence.Value.SetValue(value);
+            }
+        }
+
+        private void Reset(string key)
+        {
+            SetValue(key, _configDefualts.First(config => config.Item1.Equals(key)).Item2);
+        }
+
+        public void Reset()
+        {
+            foreach (var key in _configNames)
+            {
+                Reset(key.Value);
+            }
+        }
+    }
+}

--- a/Modules/ConfigModule.cs
+++ b/Modules/ConfigModule.cs
@@ -10,9 +10,9 @@ namespace TurtleBot.Services
     {
         private readonly IConfiguration _config;
 
-        private readonly Tuple<string, string>[] _configDefualts;
+        private readonly Tuple<string, string>[] _configDefaults;
 
-        private readonly Dictionary<string, WrapperService> refrences =
+        private readonly Dictionary<string, WrapperService> references =
             new Dictionary<string, WrapperService>();
 
         private readonly Dictionary<string, string> _configNames = new Dictionary<string, string>();
@@ -21,7 +21,7 @@ namespace TurtleBot.Services
 
         public ConfigModule(IConfiguration config)
         {
-            _configDefualts = config.GetChildren().Select(child => Tuple.Create(child.Key, child.Value)).ToArray();
+            _configDefaults = config.GetChildren().Select(child => Tuple.Create(child.Key, child.Value)).ToArray();
 
             _config = config;
         }
@@ -38,9 +38,9 @@ namespace TurtleBot.Services
                 throw new KeyNotFoundException();
             }
             
-            refrences.Add(configName, wraper);
+            references.Add(configName, wraper);
             
-            wraper.SetValue(_configDefualts.First(def => def.Item1.Equals(configName)).Item2);
+            wraper.SetValue(_configDefaults.First(def => def.Item1.Equals(configName)).Item2);
         }
 
         public void Execute(string change)
@@ -68,7 +68,7 @@ namespace TurtleBot.Services
         {
             _config[key] = value;
 
-            foreach (var refrence in refrences.Where(refrence => refrence.Key.Equals(key)))
+            foreach (var refrence in references.Where(refrence => refrence.Key.Equals(key)))
             {
                 refrence.Value.SetValue(value);
             }
@@ -76,7 +76,7 @@ namespace TurtleBot.Services
 
         private void Reset(string key)
         {
-            SetValue(key, _configDefualts.First(config => config.Item1.Equals(key)).Item2);
+            SetValue(key, _configDefaults.First(config => config.Item1.Equals(key)).Item2);
         }
 
         public void Reset()

--- a/Modules/RainModule.cs
+++ b/Modules/RainModule.cs
@@ -78,7 +78,7 @@ namespace TurtleBot.Modules
                 case "reset":
                     _config.Reset();
 
-                    ReplyAsync("Succses: All configuration values have been reset");
+                    await ReplyAsync("Succses: All configuration values have been reset");
                     break;
                 default:
 
@@ -91,11 +91,11 @@ namespace TurtleBot.Modules
                             break;
                         }
 
-                        ReplyAsync($"The current value is `{value}`");
+                        await ReplyAsync($"The current value is `{value}`");
                     }
                     catch
                     {
-                        ReplyAsync($"Error: `{subCommand}` is not a enabled");
+                        await ReplyAsync($"Error: `{subCommand}` is not a enabled");
                     }
 
                     return;
@@ -112,11 +112,11 @@ namespace TurtleBot.Modules
             {
                 _config.Execute($"{subCommand} {value}");
 
-                ReplyAsync($"Succses: The value of `{subCommand}` is now `{_config.GetValue(subCommand)}`");
+                await ReplyAsync($"Succses: The value of `{subCommand}` is now `{_config.GetValue(subCommand)}`");
             }
             catch
             {
-                ReplyAsync("Error: Unexpected value");
+                await ReplyAsync("Error: Unexpected value");
             }
         }
     }

--- a/Modules/RainModule.cs
+++ b/Modules/RainModule.cs
@@ -11,9 +11,9 @@ namespace TurtleBot.Modules
     {
         private readonly RainService _rainService;
         private readonly WalletService _walletService;
-        private readonly IConfiguration _config;
+        private readonly ConfigModule _config;
 
-        public RainModule(RainService rainService, WalletService walletService, IConfiguration config)
+        public RainModule(RainService rainService, WalletService walletService, ConfigModule config)
         {
             _rainService = rainService;
             _walletService = walletService;
@@ -36,7 +36,8 @@ namespace TurtleBot.Modules
                             .WithColor(new Color(114, 137, 218))
                             .WithTitle("See how to participate in the rain")
                             .WithUrl(_config["rainWikiUrl"])
-                            .WithDescription($"The rain is still **{missing}** TRTL away. Donate to make it rain again! ```\n{_rainService.BotWallet.Address}```")
+                            .WithDescription(
+                                $"The rain is still **{missing}** TRTL away. Donate to make it rain again! ```\n{_rainService.BotWallet.Address}```")
                             .WithThumbnailUrl(_config["rainImageUrlTRTL"])
                             .Build();
                         await ReplyAsync("", false, embed);
@@ -45,18 +46,18 @@ namespace TurtleBot.Modules
                     case RainServiceState.BalanceExceeded:
                     case RainServiceState.AcceptingRegistrations:
                     case RainServiceState.Raining:
-                        await ReplyAsync($"Be patient, little turtle, it's raining soon.");
+                        await ReplyAsync("Be patient, little turtle, it's raining soon.");
                         return;
 
                     case RainServiceState.Stopped:
                     default:
-                        await ReplyAsync($"The sky is blue, no rain for today...");
+                        await ReplyAsync("The sky is blue, no rain for today...");
                         return;
                 }
             }
             catch (Exception)
             {
-                await ReplyAsync($"The sky is blue, no rain for today...");
+                await ReplyAsync("The sky is blue, no rain for today...");
             }
         }
 
@@ -76,6 +77,40 @@ namespace TurtleBot.Modules
                     _rainService.Stop();
                     await ReplyAsync("Okay, time to go home turtles, it's not raining today.");
                     return;
+                case "reset":
+                    _config.Reset();
+
+                    ReplyAsync("Succses: All configuration values have been reset");
+                    break;
+                default:
+
+                    var value = _config.GetValue(subCommand);
+
+                    if (string.IsNullOrEmpty(value))
+                    {
+                        break;
+                    }
+
+                    ReplyAsync($"The current value is `{value}`");
+                    return;
+            }
+        }
+
+        [Command("rain")]
+        [Summary("Controls the config for the bot")]
+        [RequireBotPermission(ChannelPermission.SendMessages)]
+        [RequireOwner]
+        public async Task Rain(string subCommand, string value, [Remainder] string ignore = null)
+        {
+            try
+            {
+                _config.Execute($"{subCommand} {value}");
+
+                ReplyAsync($"Succses: The value of `{subCommand}` is now `{_config.GetValue(subCommand)}`");
+            }
+            catch
+            {
+                ReplyAsync("Error: Unexpected value");
             }
         }
     }

--- a/Modules/RainModule.cs
+++ b/Modules/RainModule.cs
@@ -48,8 +48,6 @@ namespace TurtleBot.Modules
                     case RainServiceState.Raining:
                         await ReplyAsync("Be patient, little turtle, it's raining soon.");
                         return;
-
-                    case RainServiceState.Stopped:
                     default:
                         await ReplyAsync("The sky is blue, no rain for today...");
                         return;
@@ -84,14 +82,22 @@ namespace TurtleBot.Modules
                     break;
                 default:
 
-                    var value = _config.GetValue(subCommand);
-
-                    if (string.IsNullOrEmpty(value))
+                    try
                     {
-                        break;
+                        var value = _config.GetValue(subCommand);
+
+                        if (string.IsNullOrEmpty(value))
+                        {
+                            break;
+                        }
+
+                        ReplyAsync($"The current value is `{value}`");
+                    }
+                    catch
+                    {
+                        ReplyAsync($"Error: `{subCommand}` is not a enabled");
                     }
 
-                    ReplyAsync($"The current value is `{value}`");
                     return;
             }
         }

--- a/Program.cs
+++ b/Program.cs
@@ -10,13 +10,13 @@ using TurtleBot.Services;
 
 namespace TurtleBot
 {
-    class Program
+    internal class Program
     {
         private static void Main(string[] args)
             => new Program().MainAsync().GetAwaiter().GetResult();
 
         private DiscordSocketClient _client;
-        private IConfiguration _config;
+        private ConfigModule _config;
 
         private async Task MainAsync()
         {
@@ -24,7 +24,10 @@ namespace TurtleBot
             {
                 AlwaysDownloadUsers = true
             });
-            _config = BuildConfig();
+
+            _config = new ConfigModule(BuildConfig());
+
+            RegisterSub();
 
             var services = ConfigureServices();
             services.GetRequiredService<LogService>();
@@ -37,6 +40,14 @@ namespace TurtleBot
             services.GetRequiredService<RainService>();
 
             await Task.Delay(-1);
+        }
+
+        private void RegisterSub()
+        {
+            _config.Enable("threshold", "rainBalanceThreshold");
+            _config.Enable("register", "rainRegisterDelayS");
+            _config.Enable("announce", "rainAnnounceDelayS");
+            _config.Enable("check", "rainCheckIntervalS");
         }
 
         private IServiceProvider ConfigureServices()

--- a/Services/WalletService.cs
+++ b/Services/WalletService.cs
@@ -19,7 +19,7 @@ namespace TurtleBot.Services
 
         private int _requestId;
 
-        public WalletService(ILoggerFactory loggerFactory, IConfiguration config)
+        public WalletService(ILoggerFactory loggerFactory, ConfigModule config)
         {
             _logger = loggerFactory.CreateLogger("wallet");
             _client = new HttpClient();
@@ -75,12 +75,13 @@ namespace TurtleBot.Services
             requestMessage.Content = new StringContent(content, Encoding.UTF8, "application/json");
             var response = await _client.SendAsync(requestMessage);
 
-            if (response.IsSuccessStatusCode)
+            if (!response.IsSuccessStatusCode)
             {
-                var responseString = await response.Content.ReadAsStringAsync();
-                return JObject.Parse(responseString);
+                throw new Exception($"{(int) response.StatusCode} {response.ReasonPhrase}");
             }
-            throw new Exception($"{(int)response.StatusCode} {response.ReasonPhrase}");
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            return JObject.Parse(responseString);
         }
     }
 }

--- a/Services/WrapperService.cs
+++ b/Services/WrapperService.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace TurtleBot.Services
+{
+    public class WrapperService<T> : WrapperService
+    {
+        public T Value { get; private set; }
+
+        public Func<object, T> Converter { private get; set; }
+
+        public WrapperService()
+        {
+            _valueConverter = TypeDescriptor.GetConverter(typeof(T));
+
+            Converter = value => (T) _valueConverter.ConvertFrom(value);
+        }
+
+        private readonly TypeConverter _valueConverter;
+
+
+        public object GetValue()
+        {
+            return Value;
+        }
+
+        public void SetValue(object value)
+        {
+
+            Value = Converter.Invoke(value);
+        }
+    }
+
+    public interface WrapperService
+    {
+        object GetValue();
+
+        void SetValue(object value);
+    }
+}


### PR DESCRIPTION
Resolved Issue number #3, and also removed some redundant string interpolation.

As of now, I only have rainBalanceThreshold, rainRegisterDelayS, rainAnnounceDelayS, and rainCheckIntervalS registered to be changed. The commands are as followed:
```!rain [threshold|register|announce|check] [reset|value]```